### PR TITLE
Moved to https://github.com/suse/ceph-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ceph-salt-formula - Salt formula to deploy Ceph clusters
 
+Moved to https://github.com/suse/ceph-bootstrap
+


### PR DESCRIPTION
`ceph-salt-formula` has been moved to https://github.com/suse/ceph-bootstrap

Signed-off-by: Ricardo Marques <rimarques@suse.com>